### PR TITLE
feat: generate token if needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3621,6 +3621,7 @@ version = "0.1.0"
 dependencies = [
  "hyper",
  "rand 0.8.5",
+ "reqwest",
  "serde",
  "serde_with",
  "solana-pubkey",

--- a/assist/src/close.rs
+++ b/assist/src/close.rs
@@ -19,7 +19,16 @@ const VERIFICATION_RETRY_DELAY_SECS: u64 = 20;
 /// Closes benchmark accounts and refunds rent to vault.
 pub async fn close(path: PathBuf) -> BenchResult<()> {
     tracing::info!("using config file at {path:?} to close benchmark accounts");
-    let config = Config::from_path(path)?;
+    let mut config = Config::from_path(path)?;
+    // The close flow talks to the ephemeral rollup; if it is a TEE, authenticate
+    // and append the session token to the ephemeral URL before connecting.
+    let vault = crate::common::load_vault(&config)?;
+    core::auth::authenticate_tee(
+        &mut config.connection,
+        &vault.pubkey().to_string(),
+        |message| vault.sign_message(message).to_string(),
+    )
+    .await?;
     let closer = Closer::new(&config).await?;
     closer.close_accounts().await
 }

--- a/assist/src/close.rs
+++ b/assist/src/close.rs
@@ -20,16 +20,15 @@ const VERIFICATION_RETRY_DELAY_SECS: u64 = 20;
 pub async fn close(path: PathBuf) -> BenchResult<()> {
     tracing::info!("using config file at {path:?} to close benchmark accounts");
     let mut config = Config::from_path(path)?;
+    let closer = Closer::new(&config).await?;
     // The close flow talks to the ephemeral rollup; if it is a TEE, authenticate
     // and append the session token to the ephemeral URL before connecting.
-    let vault = crate::common::load_vault(&config)?;
     core::auth::authenticate_tee(
         &mut config.connection,
-        &vault.pubkey().to_string(),
-        |message| vault.sign_message(message).to_string(),
+        &closer.vault.pubkey().to_string(),
+        |message| closer.vault.sign_message(message).to_string(),
     )
     .await?;
-    let closer = Closer::new(&config).await?;
     closer.close_accounts().await
 }
 
@@ -85,12 +84,7 @@ impl Closer {
             // Commit and undelegate this batch
             let hash = self.ephem_client.get_latest_blockhash().await?;
             let ix = self.build_commit_undelegate_ix(idx as u64, payer, batch);
-            let txn = Transaction::new_signed_with_payer(
-                &[ix],
-                Some(&payer),
-                &[&self.vault],
-                hash,
-            );
+            let txn = Transaction::new_signed_with_payer(&[ix], Some(&payer), &[&self.vault], hash);
             self.ephem_client.send_and_confirm_transaction(&txn).await?;
             tracing::info!(
                 "batch {}/{}: committed and undelegated {} accounts",
@@ -144,7 +138,6 @@ impl Closer {
             Rc::try_unwrap(non_delegated).unwrap().into_inner(),
         ))
     }
-
 
     async fn verify_undelegation(self: &Rc<Self>, accounts: &[Pubkey]) -> BenchResult<()> {
         for retry in 0..VERIFICATION_MAX_RETRIES {

--- a/assist/src/close.rs
+++ b/assist/src/close.rs
@@ -78,7 +78,7 @@ impl Closer {
 
     async fn process_delegated_accounts(self: &Rc<Self>, accounts: &[Pubkey]) -> BenchResult<()> {
         let payer = self.vault.pubkey();
-        let total_batches = (accounts.len() + COMMIT_BATCH_SIZE - 1) / COMMIT_BATCH_SIZE;
+        let total_batches = accounts.len().div_ceil(COMMIT_BATCH_SIZE);
 
         for (idx, batch) in accounts.chunks(COMMIT_BATCH_SIZE).enumerate() {
             // Commit and undelegate this batch

--- a/bencher/src/main.rs
+++ b/bencher/src/main.rs
@@ -15,7 +15,7 @@ use json::writer::BufferedWriter;
 use keypair::Keypair;
 use runner::BenchRunner;
 use signal_hook::{consts::*, low_level};
-use signer::EncodableKey;
+use signer::{EncodableKey, Signer};
 use tokio::{runtime, sync::broadcast, task::LocalSet};
 use tracing_subscriber::EnvFilter;
 
@@ -34,7 +34,10 @@ fn main() -> BenchResult<()> {
         .init();
 
     // Load the configuration from command-line arguments
-    let config = Config::from_args()?;
+    let mut config = Config::from_args()?;
+    // If the ephemeral rollup is a TEE, run the PER auth flow and append the
+    // resulting session token to the ephemeral URL before any connection is made.
+    authenticate_tee(&mut config)?;
     let keypairs: Vec<_> = (1..=config.payers * config.parallelism)
         .map(|n| Keypair::read_from_file(config.keypairs.join(format!("{n}.json"))))
         .collect::<BenchResult<_>>()?;
@@ -105,6 +108,25 @@ fn main() -> BenchResult<()> {
     }
 
     Ok(())
+}
+
+/// Runs the PER (TEE) authentication flow if the config marks the ephemeral
+/// rollup as a TEE, appending the obtained session token to the ephemeral URL.
+/// The vault keypair is used as the authenticating identity.
+fn authenticate_tee(config: &mut Config) -> BenchResult<()> {
+    if !config.connection.tee {
+        return Ok(());
+    }
+    let vault = Keypair::read_from_file(config.keypairs.join("vault.json"))?;
+    let pubkey = vault.pubkey().to_string();
+    let rt = runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(core::auth::authenticate_tee(
+        &mut config.connection,
+        &pubkey,
+        |message| vault.sign_message(message).to_string(),
+    ))
 }
 
 /// Sets up signal handlers for graceful shutdown on SIGTERM/SIGINT

--- a/config.example.toml
+++ b/config.example.toml
@@ -49,6 +49,11 @@ http-connection-type = "http2"
 http-connections-count = 16
 # Maximum number of WebSocket connections to establish.
 ws-connections-count = 16
+# Whether the ephemeral rollup is a Private Ephemeral Rollup (PER) running in a TEE.
+# When true, the authentication flow runs automatically during setup to obtain a
+# session token, which is appended to `ephem-url` as a `?token=...` query parameter.
+# The vault keypair is used as the authenticating identity.
+tee = false
 
 # ## Benchmark Settings
 #

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,3 +19,4 @@ tracing = { workspace = true }
 rand = { workspace = true }
 toml = "0.8"
 serde_with = "3"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -29,7 +29,6 @@ struct LoginRequest<'a> {
 #[derive(Deserialize)]
 struct LoginResponse {
     token: Option<String>,
-    error: Option<String>,
 }
 
 /// Runs the PER auth flow against `base_url` and returns a session token.
@@ -71,12 +70,12 @@ pub async fn fetch_auth_token(
         })
         .send()
         .await?;
-    let succeeded = response.status().is_success();
-    let login: LoginResponse = response.json().await?;
-    if !succeeded {
-        let error = login.error.unwrap_or_else(|| "unknown error".into());
-        return Err(format!("TEE authentication failed: {error}").into());
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!("TEE authentication failed: {status} - {body}").into());
     }
+    let login: LoginResponse = response.json().await?;
     login
         .token
         .filter(|t| !t.is_empty())

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -5,9 +5,13 @@
 //! signs it, exchanges the signature for a session token, and appends that token
 //! to the RPC URL as a `token` query parameter.
 
+use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{config::ConnectionSettings, types::BenchResult};
+
+const AUTH_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Deserialize)]
 struct ChallengeResponse {
@@ -37,7 +41,7 @@ pub async fn fetch_auth_token(
     pubkey: &str,
     sign_base58: impl FnOnce(&[u8]) -> String,
 ) -> BenchResult<String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder().timeout(AUTH_TIMEOUT).build()?;
 
     // 1. Request a challenge for this pubkey.
     let challenge: ChallengeResponse = client

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -1,0 +1,98 @@
+//! Private Ephemeral Rollup (PER) authentication.
+//!
+//! When the ephemeral rollup runs inside a TEE, RPC access is gated behind a
+//! challenge/response auth flow: the client requests a challenge for its pubkey,
+//! signs it, exchanges the signature for a session token, and appends that token
+//! to the RPC URL as a `token` query parameter.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{config::ConnectionSettings, types::BenchResult};
+
+#[derive(Deserialize)]
+struct ChallengeResponse {
+    challenge: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Serialize)]
+struct LoginRequest<'a> {
+    pubkey: &'a str,
+    challenge: &'a str,
+    signature: &'a str,
+}
+
+#[derive(Deserialize)]
+struct LoginResponse {
+    token: Option<String>,
+    error: Option<String>,
+}
+
+/// Runs the PER auth flow against `base_url` and returns a session token.
+///
+/// `sign_base58` receives the raw challenge bytes and must return the detached
+/// ed25519 signature encoded as base58.
+pub async fn fetch_auth_token(
+    base_url: &str,
+    pubkey: &str,
+    sign_base58: impl FnOnce(&[u8]) -> String,
+) -> BenchResult<String> {
+    let client = reqwest::Client::new();
+
+    // 1. Request a challenge for this pubkey.
+    let challenge: ChallengeResponse = client
+        .get(format!("{base_url}/auth/challenge?pubkey={pubkey}"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    if let Some(error) = challenge.error.filter(|e| !e.is_empty()) {
+        return Err(format!("TEE auth challenge failed: {error}").into());
+    }
+    let challenge = challenge
+        .challenge
+        .filter(|c| !c.is_empty())
+        .ok_or("TEE auth endpoint returned no challenge")?;
+
+    // 2. Sign the challenge bytes and base58-encode the signature.
+    let signature = sign_base58(challenge.as_bytes());
+
+    // 3. Exchange the signed challenge for a session token.
+    let response = client
+        .post(format!("{base_url}/auth/login"))
+        .json(&LoginRequest {
+            pubkey,
+            challenge: &challenge,
+            signature: &signature,
+        })
+        .send()
+        .await?;
+    let succeeded = response.status().is_success();
+    let login: LoginResponse = response.json().await?;
+    if !succeeded {
+        let error = login.error.unwrap_or_else(|| "unknown error".into());
+        return Err(format!("TEE authentication failed: {error}").into());
+    }
+    login
+        .token
+        .filter(|t| !t.is_empty())
+        .ok_or_else(|| "TEE auth endpoint returned no token".into())
+}
+
+/// If `connection` targets a TEE, runs the auth flow and appends the resulting
+/// token to `connection.ephem_url`. Otherwise does nothing.
+pub async fn authenticate_tee(
+    connection: &mut ConnectionSettings,
+    pubkey: &str,
+    sign_base58: impl FnOnce(&[u8]) -> String,
+) -> BenchResult<()> {
+    if !connection.tee {
+        return Ok(());
+    }
+    let base_url = connection.ephem_url.origin();
+    tracing::info!("ephemeral rollup is a TEE, authenticating at {base_url}");
+    let token = fetch_auth_token(&base_url, pubkey, sign_base58).await?;
+    connection.ephem_url = connection.ephem_url.with_token(&token)?;
+    tracing::info!("TEE authentication succeeded, session token appended to ephemeral URL");
+    Ok(())
+}

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -93,6 +93,12 @@ pub struct ConnectionSettings {
     pub http_connections_count: usize,
     /// The maximum number of WebSocket connections to establish.
     pub ws_connections_count: usize,
+    /// Whether the ephemeral rollup is a Private Ephemeral Rollup running in a TEE.
+    ///
+    /// When `true`, the PER authentication flow runs during setup to obtain a
+    /// session token, which is automatically appended to `ephem_url`.
+    #[serde(default)]
+    pub tee: bool,
 }
 
 /// # Benchmark Settings

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod config;
 pub mod consts;
 pub mod stats;

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -120,6 +120,24 @@ impl Url {
     pub fn host(&self) -> &str {
         self.0.host().expect("uri has no host")
     }
+
+    /// Returns the `scheme://authority` origin of the URL, without any path or query.
+    pub fn origin(&self) -> String {
+        let scheme = self.0.scheme_str().unwrap_or("http");
+        let authority = self.0.authority().map(|a| a.as_str()).unwrap_or_default();
+        format!("{scheme}://{authority}")
+    }
+
+    /// Returns a copy of the URL with the given auth `token` appended as a query parameter.
+    pub fn with_token(&self, token: &str) -> BenchResult<Self> {
+        let path = self.0.path();
+        let path_and_query = match self.0.query() {
+            Some(query) if !query.is_empty() => format!("{path}?{query}&token={token}"),
+            _ => format!("{path}?token={token}"),
+        };
+        let full = format!("{}{path_and_query}", self.origin());
+        full.parse::<hyper::Uri>().map(Url).map_err(Into::into)
+    }
 }
 
 impl<'de> Deserialize<'de> for Url {


### PR DESCRIPTION
TEE validators need an auth token to accept some requests. This PR adds the auth as part of the flow to avoid having to do it manually and put the token in the config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Trusted Execution Environment (TEE) authentication support for Private Ephemeral Rollup deployments. When enabled via the new `tee` configuration option, automatic authentication occurs during startup and session tokens are transparently managed for secure API communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->